### PR TITLE
Added Fix for torchvision models

### DIFF
--- a/torch_ort_inference/torch_ort/ortinferencemodule/utils.py
+++ b/torch_ort_inference/torch_ort/ortinferencemodule/utils.py
@@ -36,3 +36,20 @@ def patch_ortinferencemodule_forward_method(ortinferencemodule):
     ortinferencemodule.forward = _forward.__get__(ortinferencemodule)
     # Copy the forward signature from the PyTorch module
     functools.update_wrapper(ortinferencemodule.forward.__func__, ortinferencemodule._original_module.forward.__func__)
+
+
+def set_dynamic_axes(module):
+
+    """Returns true if dynamic_axes parameter needs to be set for
+    onnx export
+    Args:
+        module (torch.nn.Module): Pytorch model
+    """
+    try:
+        avg_pool_module = module._original_module.get_submodule("avgpool")
+        output_size = list(avg_pool_module.output_size)
+        if output_size != [1] * len(output_size):
+            return False
+    except Exception:
+        return True
+    return True


### PR DESCRIPTION
This fix is needed for some of the torchvision models like alexnet, vggs to get exported to onnx correctly. If the dynamic axes parameter of onnx export is set for these models, onnx export fails "adaptive_avg_pool2d is not a registered function/op" error. So for these models we need to disable the dynamic axes : True parameter to onnx export for successfully exporting them.