### PR TITLE
Creating Docker Containers for Demo Samples Inference

### DIFF
--- a/torch_ort_inference/docker/Dockerfile.ort-infer-stable-torch1120-onnxruntime1120-openvino-ubuntu18.04
+++ b/torch_ort_inference/docker/Dockerfile.ort-infer-stable-torch1120-onnxruntime1120-openvino-ubuntu18.04
@@ -1,0 +1,22 @@
+#-------------------------------------------------------------------------
+# Copyright(C) 2022 Intel Corporation.
+# SPDX-License-Identifier: MIT
+#--------------------------------------------------------------------------
+
+FROM ubuntu:18.04
+
+RUN apt update; \ 
+    apt install -y software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt install -y python3.8
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2;
+
+RUN apt install -y python3-pip && python3 -m pip install --upgrade pip
+ 
+RUN pip install torch-ort-infer[openvino]
+
+RUN pip install wget pandas transformers pillow torchvision
+
+# RUN python -m torch_ort.configure

--- a/torch_ort_inference/docker/Dockerfile.ort-infer-stable-torch1120-onnxruntime1120-openvino-ubuntu20.04
+++ b/torch_ort_inference/docker/Dockerfile.ort-infer-stable-torch1120-onnxruntime1120-openvino-ubuntu20.04
@@ -1,0 +1,22 @@
+#-------------------------------------------------------------------------
+# Copyright(C) 2022 Intel Corporation.
+# SPDX-License-Identifier: MIT
+#--------------------------------------------------------------------------
+
+FROM ubuntu:20.04
+
+RUN apt update; \ 
+    apt install -y software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt install -y python3.8
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2;
+
+RUN apt install -y python3-pip && python3 -m pip install --upgrade pip
+ 
+RUN pip install torch-ort-infer[openvino]
+
+RUN pip install wget pandas transformers pillow torchvision
+
+# RUN python -m torch_ort.configure

--- a/torch_ort_inference/docker/README.md
+++ b/torch_ort_inference/docker/README.md
@@ -1,0 +1,19 @@
+# OpenVINO™ integration with PyTorch ONNX Runtime Dockerfiles for Ubuntu* 18.04 and Ubuntu* 20.04
+
+
+We provide Dockerfiles for Ubuntu* 18.04 and Ubuntu* 20.04 which can be used to build runtime Docker* images for OpenVINO™ integration with PyTorch on CPU.
+They contain all required runtime python packages, and shared libraries to support execution of a PyTorch Python app with the OpenVINO™ backend. By default, it hosts an Image Classification and Sequence Classification sample that demonstrate the performance benefits of using OpenVINO™ integration with PyTorch.
+
+Build the docker image
+
+	cd torch_ort_inference\docker\
+    docker build -f .\Dockerfile.ort-infer-stable-torch1120-onnxruntime1120-openvino-ubuntu20.04 -t ort_infer_ubuntu20 .
+
+To run on **CPU** backend:
+
+	docker run -it --rm \
+		   -v <path to demos directory>:/home/ \
+		   ort_infer_ubuntu20
+
+---
+\* Other names and brands may be claimed as the property of others.


### PR DESCRIPTION
This PR enables new Dockerfiles addition for demo samples inference.
- [x] Uses Ubuntu 20.04 and Ubuntu 18.04 as base images.
- [x] Uses Python 3.8 installation during the build stage.
- [x] Uses torch-ort-infer latest stable release.
- [ ] Missing/Disabled torch_ort.configure option; this will be enabled once the ATEN support is added to the release package.
- [ ] This container will be hosted to Dockerhub in the future.