### PR TITLE
enabling aten fallback for inference

### DIFF
--- a/torch_ort_inference/torch_ort/ortinferencemodule/_custom_op_symbolic_registry.py
+++ b/torch_ort_inference/torch_ort/ortinferencemodule/_custom_op_symbolic_registry.py
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import torch
+from packaging.version import Version
+from torch.onnx import register_custom_op_symbolic
+
+class CustomOpSymbolicRegistry:
+    _SYMBOLICS = {}
+
+    @classmethod
+    def register(cls, name, domain, fn):
+        cls._SYMBOLICS[domain + "::" + name] = fn
+
+    @classmethod
+    def register_all(cls):
+        for name, fn in cls._SYMBOLICS.items():
+            # Symbolic name is in format: domain::name
+            # Exporter will fail to register symbolic with non-empty domain when torch version is < 1.11.0.
+            if Version(torch.__version__) >= Version("1.11.0") or name.startswith("::"):
+                register_custom_op_symbolic(name, fn, 1)
+
+
+def register_symbolic(name, domain=""):
+    def symbolic_wrapper(fn):
+        CustomOpSymbolicRegistry.register(name, domain, fn)
+        return fn
+
+    return symbolic_wrapper
+
+@register_symbolic("grid_sampler")
+def grid_sampler(g, self, grid, mode, padding_mode, align_corners):
+    output = g.op("org.pytorch.aten::ATen", self, grid, mode, padding_mode, align_corners, operator_s="grid_sampler")
+    output.setType(self.type())
+    return output
+
+@register_symbolic("triu")
+def triu(g, self, diagonal, out=None):
+    out = g.op("org.pytorch.aten::ATen", self, diagonal, operator_s="triu")
+    out.setType(self.type())
+    return out
+
+@register_symbolic("tril")
+def tril(g, self, diagonal, out=None):
+    out = g.op("org.pytorch.aten::ATen", self, diagonal, operator_s="tril")
+    out.setType(self.type())
+    return out
+
+    

--- a/torch_ort_inference/torch_ort/ortinferencemodule/_utils_infer.py
+++ b/torch_ort_inference/torch_ort/ortinferencemodule/_utils_infer.py
@@ -6,7 +6,6 @@
 import functools
 from collections import abc
 from onnxruntime.training.ortmodule import _io
-from torch.onnx import register_custom_op_symbolic
 
 def get_device_from_module(module):
     """Returns the first device found in the `module`'s parameters or None
@@ -132,22 +131,3 @@ def set_dynamic_axes(module):
     except Exception:
         return True
     return True
-
-def post_process_after_export(exported_model):
-
-    for node in exported_model.graph.node:
-        if node.op_type == "ATen":
-            attr = node.attribute[0]
-            aten_op = attr.s.decode("utf-8") if isinstance(attr.s, bytes) else attr.s
-            if aten_op in ["grid_sampler", "triu"]:
-                post_process_set_atenop_output_types(aten_op)
-
-def post_process_set_atenop_output_types(aten_op):
-
-    # Set output type for Aten ops
-    def aten(g, self, x):
-        output = g.op("org.pytorch.aten::ATen", self, x, operator_s=aten_op)
-        output.setType(self.type())
-        return output
-
-    register_custom_op_symbolic("::"+ aten_op, aten, 1)

--- a/torch_ort_inference/torch_ort/ortinferencemodule/ortinferencemodule.py
+++ b/torch_ort_inference/torch_ort/ortinferencemodule/ortinferencemodule.py
@@ -187,6 +187,8 @@ class ORTInferenceModule(torch.nn.Module):
         # Handling aten op output types to enable aten fallback
         _utils_infer.post_process_after_export(exported_model)
 
+        return exported_model
+        
     def _get_session_config(self):
         """Creates and returns the session configuration to be used."""
 

--- a/torch_ort_inference/torch_ort/ortinferencemodule/ortinferencemodule.py
+++ b/torch_ort_inference/torch_ort/ortinferencemodule/ortinferencemodule.py
@@ -57,6 +57,8 @@ class ORTInferenceModule(torch.nn.Module):
         self._export_extra_kwargs = {}
         self._provider_options = provider_options
         self._inference_session = None
+        self._input_info = None
+        self._module_output_schema  = None
         # Enable ATen Fallback
         load_aten_op_executor_cpp_extension()
         _custom_op_symbolic_registry.CustomOpSymbolicRegistry.register_all()

--- a/torch_ort_inference/torch_ort/ortinferencemodule/ortinferencemodule.py
+++ b/torch_ort_inference/torch_ort/ortinferencemodule/ortinferencemodule.py
@@ -15,6 +15,7 @@ import onnxruntime
 from onnxruntime.capi import _pybind_state as C
 from onnxruntime.training.ortmodule import _io, _onnx_models, _utils
 from onnxruntime.training.ortmodule.debug_options import DebugOptions, LogLevel
+from onnxruntime.training.ortmodule.torch_cpp_extensions.cpu.aten_op_executor import load_aten_op_executor_cpp_extension
 
 from .provider_options import OpenVINOProviderOptions
 from . import _utils_infer
@@ -55,6 +56,8 @@ class ORTInferenceModule(torch.nn.Module):
         self._export_extra_kwargs = {}
         self._provider_options = provider_options
         self._inference_session = None
+        # Load ATen operator executor extension.
+        load_aten_op_executor_cpp_extension()
 
     def _forward_call(self, *inputs, **kwargs):
         """Delegate the :meth:`~torch.nn.Module.forward` to
@@ -179,7 +182,10 @@ class ORTInferenceModule(torch.nn.Module):
                 "Model could not be exported to ONNX"
             ) from e
 
-        return onnx.load_model_from_string(f.getvalue())
+        exported_model = onnx.load_model_from_string(f.getvalue())
+
+        # Handling aten op output types to enable aten fallback
+        _utils_infer.post_process_after_export(exported_model)
 
     def _get_session_config(self):
         """Creates and returns the session configuration to be used."""


### PR DESCRIPTION
This PR adds code changes to set output types for aten ops to enable aten fallback on native pytorch runtime